### PR TITLE
Remove the 'undefined' logic as it does not work

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # json-helpers
-Provide a JSON stringify/parser able to manage 'undefined', 'Date', 'Uint8Array' and 'Buffer'.
+Provide a JSON stringify/parser able to manage 'Date', 'Uint8Array' and 'Buffer'.
 You can add your own class formatter.
 
 This parser is pretty efficient as using the standard JSON implementation, just overriding the 'toJSON' methods of classes.  
@@ -29,9 +29,8 @@ const busEvent = {
           pid: 2000,
           rid: 2,
           wcid: 10,
-          testUndefined: undefined
         },
-        testArrayUndefined: [12, "str", undefined, 3, null, new Date(), "end"],
+        testArray: [12, "str", 3, null, new Date(), "end"],
         testBuffer: Buffer.from('ceci est un test')
       },
       request: {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "json-helpers",
   "version": "5.2.1",
-  "description": "JSON stringify/parser managing 'undefined, Date and Buffer.",
+  "description": "JSON stringify/parser managing 'Date and Buffer.",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/emmkimme/json-helpers.git"
@@ -20,7 +20,6 @@
     "stringify",
     "Buffer",
     "Date",
-    "undefined",
     "Uint8Array"
   ],
   "author": "Emmanuel Kimmerlin",

--- a/src/code/json-parser-test.ts_
+++ b/src/code/json-parser-test.ts_
@@ -5,7 +5,7 @@ import { JSONReplacerInstanceOfImpl as JSONReplacerTestInstance } from './json-r
 // import { JSONReplacerPrototypeImpl as JSONReplacerTestInstance } from './json-replacer-prototype-impl';
 import type { JSONFormatterData } from './json-formatter';
 
-// Purpose is to manage 'undefined', 'Buffer' and 'Date'
+// Purpose is to manage 'Buffer' and 'Date'
 class JSONParserTestImpl extends JSONParserImpl {
     protected _jsonReplacerInstanceOf: JSONReplacerTestInstance;
 

--- a/src/code/json-parser-v1.ts
+++ b/src/code/json-parser-v1.ts
@@ -2,7 +2,7 @@ import { DateJSONFormatter, ErrorJSONFormatter, TypeErrorJSONFormatter, BufferJS
 import { JSONParserImpl } from './json-parser-impl';
 import type { JSONParserInterface } from './json-parser';
 
-// Purpose is to manage 'undefined', 'Buffer' and 'Date'
+// Purpose is to manage 'Buffer' and 'Date'
 class JSONParserV1Impl extends JSONParserImpl {
     constructor() {
         super();

--- a/src/code/json-parser-v2.ts
+++ b/src/code/json-parser-v2.ts
@@ -2,7 +2,7 @@ import { DateJSONFormatter, ErrorJSONFormatter, TypeErrorJSONFormatter, BufferBi
 import { JSONParserImpl } from './json-parser-impl';
 import type { JSONParserInterface } from './json-parser';
 
-// Purpose is to manage 'undefined', 'Buffer' and 'Date'
+// Purpose is to manage 'Buffer' and 'Date'
 class JSONParserV2Impl extends JSONParserImpl {
     constructor() {
         super();

--- a/src/code/json-parser.ts
+++ b/src/code/json-parser.ts
@@ -1,9 +1,5 @@
 import type { JSONFormatterData, JSONReplacerData, JSONReviverData } from "./json-formatter";
 
-export namespace ToJSONConstants {
-    export const JSON_TOKEN_UNDEFINED = '_/undefined/_';
-}
-
 export interface JSONLike {
     stringify(value: any, replacer?: (key: string, value: any) => any, space?: string | number): string;
     parse(text: string, reviver?: (key: string, value: any) => any): any;

--- a/src/code/json-replacer-instanceof-impl.ts
+++ b/src/code/json-replacer-instanceof-impl.ts
@@ -35,7 +35,7 @@ function getObjectClass(constructor: any): string | null {
 }
 
 
-// Purpose is to manage 'undefined', 'Buffer', 'Date', 'Error', 'TypeError'
+// Purpose is to manage 'Buffer', 'Date', 'Error', 'TypeError'
 class JSONReplacerSetup<T extends Object> implements JSONReplacerData<T> {
     objectType: string;
     // objectInstance: T;
@@ -78,10 +78,7 @@ export class JSONReplacerInstanceOfImpl implements JSONReplacer {
         }
     }
 
-    private _replacer(key: string, value: any): any {
-        if (typeof key === 'undefined') {
-            return ToJSONConstants.JSON_TOKEN_UNDEFINED;
-        }
+    private _replacer(_key: string, value: any): any {
         if ((typeof value === 'object') && value && value.constructor) {
             const objectClass = getObjectClass(value.constructor);
             if (objectClass) {
@@ -95,9 +92,6 @@ export class JSONReplacerInstanceOfImpl implements JSONReplacer {
     }
 
     private _replacerChain(replacer: (key: string, value: any) => any, key: string, value: any) {
-        if (typeof key === 'undefined') {
-            return ToJSONConstants.JSON_TOKEN_UNDEFINED;
-        }
         if (value && value.constructor) {
             const objectClass = getObjectClass(value.constructor);
             if (objectClass) {

--- a/src/code/json-replacer-prototype-impl.ts
+++ b/src/code/json-replacer-prototype-impl.ts
@@ -2,7 +2,7 @@ import type { JSONReplacer } from './json-parser';
 import { ToJSONConstants } from './json-parser';
 import type { JSONReplacerData } from './json-formatter';
 
-// Purpose is to manage 'undefined', 'Buffer', 'Date', 'Error', 'TypeError'
+// Purpose is to manage 'Buffer', 'Date', 'Error', 'TypeError'
 class JSONReplacerSetup<T extends Object> implements JSONReplacerData<T> {
     objectType: string;
     // objectInstance: T;
@@ -74,20 +74,6 @@ export class JSONReplacerPrototypeImpl implements JSONReplacer {
         else {
             this._jsonReplacerSetupsMap.delete(setup.toJSONPrototype);
         }
-    }
-
-    private _replacer(key: string, value: any): any {
-        if (typeof key === 'undefined') {
-            return ToJSONConstants.JSON_TOKEN_UNDEFINED;
-        }
-        return value;
-    }
-
-    private _replacerChain(replacer: (key: string, value: any) => any, key: string, value: any) {
-        if (typeof key === 'undefined') {
-            return ToJSONConstants.JSON_TOKEN_UNDEFINED;
-        }
-        return replacer(key, value);
     }
 
     install(): void {

--- a/src/code/json-replacer-tojson-impl.ts
+++ b/src/code/json-replacer-tojson-impl.ts
@@ -1,5 +1,4 @@
 import type { JSONReplacer } from './json-parser';
-import { ToJSONConstants } from './json-parser';
 import type { JSONReplacerData } from './json-formatter';
 
 function findFunctionPrototype(objectConstructor: Function, name: string): [any, PropertyDescriptor] | null {
@@ -21,7 +20,7 @@ function findFunctionPrototype(objectConstructor: Function, name: string): [any,
     return null;
 }
 
-// Purpose is to manage 'undefined', 'Buffer', 'Date', 'Error', 'TypeError'
+// Purpose is to manage 'Buffer', 'Date', 'Error', 'TypeError'
 class JSONReplacerSetup<T extends Object> implements JSONReplacerData<T> {
     objectType: string;
     // objectInstance: T;
@@ -115,9 +114,6 @@ export class JSONReplacerToJSONImpl implements JSONReplacer {
     constructor() {
         this._jsonReplacerSetupsMap = new Map<Object, JSONReplacerSetup<any>>();
         this._installed = 0;
-
-        // callback
-        this._replacer = this._replacer.bind(this)
     }
 
     replacer<T>(replacer: JSONReplacerData<T>) {
@@ -128,20 +124,6 @@ export class JSONReplacerToJSONImpl implements JSONReplacer {
         else {
             this._jsonReplacerSetupsMap.delete(setup.objectConstructor);
         }
-    }
-
-    private _replacer(key: string, value: any): any {
-        if (typeof key === 'undefined') {
-            return ToJSONConstants.JSON_TOKEN_UNDEFINED;
-        }
-        return value;
-    }
-
-    private _replacerChain(replacer: (key: string, value: any) => any, key: string, value: any) {
-        if (typeof key === 'undefined') {
-            return ToJSONConstants.JSON_TOKEN_UNDEFINED;
-        }
-        return replacer(key, value);
     }
 
     install(): void {
@@ -163,8 +145,7 @@ export class JSONReplacerToJSONImpl implements JSONReplacer {
     stringify(value: any, replacer?: (key: string, value: any) => any, space?: string | number): string {
         try {
             this.install();
-            const replacerCb = replacer ? this._replacerChain.bind(this, replacer) : this._replacer;
-            const result = JSON.stringify(value, replacerCb, space);
+            const result = JSON.stringify(value, replacer, space);
             this.uninstall();
             return result;
         }

--- a/src/code/json-reviver-impl.ts
+++ b/src/code/json-reviver-impl.ts
@@ -1,5 +1,4 @@
 import type { JSONReviver } from './json-parser';
-import { ToJSONConstants } from './json-parser';
 import type { JSONReviverData } from './json-formatter';
 
 /** @internal */
@@ -24,9 +23,6 @@ export class JSONReviverImpl implements JSONReviver {
    
     private _reviver(key: string, value: any) {
         if (value) {
-            if (value === ToJSONConstants.JSON_TOKEN_UNDEFINED) {
-                return undefined;
-            }
             // Is it JSONFormatter ? - duck typing
             if ((typeof value.type === 'string') && ('data' in value)) {
                 const format = this._jsonReviversMap.get(value.type);
@@ -40,9 +36,6 @@ export class JSONReviverImpl implements JSONReviver {
     
     private _reviverChain(reviver: (key: string, value: any) => any, key: string, value: any): any {
         if (value) {
-            if (value === ToJSONConstants.JSON_TOKEN_UNDEFINED) {
-                return undefined;
-            }
             // Is it JSONFormatter ? - duck typing
             if ((typeof value.type === 'string') && ('data' in value)) {
                 const format = this._jsonReviversMap.get(value.type);

--- a/test/browser-tests/browser-test.bundle.js
+++ b/test/browser-tests/browser-test.bundle.js
@@ -119,11 +119,7 @@ exports.JSONParserV2 = new JSONParserV2Impl();
 },{"./json-formatter-default":1,"./json-parser-impl":2}],5:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.IsJSONLike = exports.ToJSONConstants = void 0;
-var ToJSONConstants;
-(function (ToJSONConstants) {
-    ToJSONConstants.JSON_TOKEN_UNDEFINED = '_/undefined/_';
-})(ToJSONConstants = exports.ToJSONConstants || (exports.ToJSONConstants = {}));
+exports.IsJSONLike = void 0;
 function IsJSONLike(obj) {
     return ((typeof obj === 'object') && obj.stringify && obj.parse);
 }
@@ -133,7 +129,6 @@ exports.IsJSONLike = IsJSONLike;
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.JSONReplacerToJSONImpl = void 0;
-const json_parser_1 = require("./json-parser");
 function findFunctionPrototype(objectConstructor, name) {
     let proto = objectConstructor.prototype;
     let toJSONDescriptor = Object.getOwnPropertyDescriptor(proto, name);
@@ -206,7 +201,6 @@ class JSONReplacerToJSONImpl {
     constructor() {
         this._jsonReplacerSetupsMap = new Map();
         this._installed = 0;
-        this._replacer = this._replacer.bind(this);
     }
     replacer(replacer) {
         const setup = new JSONReplacerSetup(replacer);
@@ -216,18 +210,6 @@ class JSONReplacerToJSONImpl {
         else {
             this._jsonReplacerSetupsMap.delete(setup.objectConstructor);
         }
-    }
-    _replacer(key, value) {
-        if (typeof key === 'undefined') {
-            return json_parser_1.ToJSONConstants.JSON_TOKEN_UNDEFINED;
-        }
-        return value;
-    }
-    _replacerChain(replacer, key, value) {
-        if (typeof key === 'undefined') {
-            return json_parser_1.ToJSONConstants.JSON_TOKEN_UNDEFINED;
-        }
-        return replacer(key, value);
     }
     install() {
         if (this._installed++ === 0) {
@@ -246,8 +228,7 @@ class JSONReplacerToJSONImpl {
     stringify(value, replacer, space) {
         try {
             this.install();
-            const replacerCb = replacer ? this._replacerChain.bind(this, replacer) : this._replacer;
-            const result = JSON.stringify(value, replacerCb, space);
+            const result = JSON.stringify(value, replacer, space);
             this.uninstall();
             return result;
         }
@@ -259,11 +240,10 @@ class JSONReplacerToJSONImpl {
 }
 exports.JSONReplacerToJSONImpl = JSONReplacerToJSONImpl;
 
-},{"./json-parser":5}],7:[function(require,module,exports){
+},{}],7:[function(require,module,exports){
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.JSONReviverImpl = void 0;
-const json_parser_1 = require("./json-parser");
 class JSONReviverImpl {
     constructor() {
         this._jsonReviversMap = new Map();
@@ -279,9 +259,6 @@ class JSONReviverImpl {
     }
     _reviver(key, value) {
         if (value) {
-            if (value === json_parser_1.ToJSONConstants.JSON_TOKEN_UNDEFINED) {
-                return undefined;
-            }
             if ((typeof value.type === 'string') && ('data' in value)) {
                 const format = this._jsonReviversMap.get(value.type);
                 if (format) {
@@ -293,9 +270,6 @@ class JSONReviverImpl {
     }
     _reviverChain(reviver, key, value) {
         if (value) {
-            if (value === json_parser_1.ToJSONConstants.JSON_TOKEN_UNDEFINED) {
-                return undefined;
-            }
             if ((typeof value.type === 'string') && ('data' in value)) {
                 const format = this._jsonReviversMap.get(value.type);
                 if (format) {
@@ -312,7 +286,7 @@ class JSONReviverImpl {
 }
 exports.JSONReviverImpl = JSONReviverImpl;
 
-},{"./json-parser":5}],8:[function(require,module,exports){
+},{}],8:[function(require,module,exports){
 "use strict";
 var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
     if (k2 === undefined) k2 = k;
@@ -21990,9 +21964,8 @@ const complexJSON = {
       pid: 2000,
       rid: 2,
       wcid: 10,
-      testUndefined: undefined
     },
-    testArrayUndefined: [12, "str", undefined, 3, null, new Date(), "end"]
+    testArray: [12, "str", 3, null, new Date(), "end"]
   },
   request: {
     replyChannel: '/electron-common-ipc/myChannel/myRequest/replyChannel',

--- a/test/json-parser.test.js
+++ b/test/json-parser.test.js
@@ -5,7 +5,8 @@ const expect = chai.expect;
 const json_tools = require('../lib/json-helpers');
 
 function ObjectEqual(a1, a2) {
-  return JSON.stringify(a1) === JSON.stringify(a2);
+  expect(a1).to.be.deep.eq(a2);
+  return true;
 }
 
 function TestPerformance(myValue, nameTypeOf, compare, jsonparse) {
@@ -77,9 +78,8 @@ const complexJSON = {
       pid: 2000,
       rid: 2,
       wcid: 10,
-      testUndefined: undefined
     },
-    testArrayUndefined: [12, "str", undefined, 3, null, new Date(), "end"]
+    testArray: [12, "str", 3, null, new Date(), "end"]
   },
   request: {
     replyChannel: '/electron-common-ipc/myChannel/myRequest/replyChannel',


### PR DESCRIPTION
- to improve upon this topic we must act really careful(to not affect performance of socket-serializer -> RW), because it is easy to turn the undefined in some kind of flag within the JSON.stringify but to turn it back to the undefined we need to traverse object/array AFTER JSON.parse() and replace placeholders with undefined hence altering Hidden Classes of the V8 + looping through each property 😢  @emmkimme 